### PR TITLE
The latest stuff from my working branch.

### DIFF
--- a/etc/Edscension/todo.txt
+++ b/etc/Edscension/todo.txt
@@ -1,0 +1,47 @@
+
+TODO:
+  horus, shed, sgeea, cure-all, etc.  not sure what things need to be done, exactly....  but we need to avoid unnecessary use of cure-alls.
+  Decision to do nuns might not be quite right.  I count a difference of about
+25 turns on the battlefield.  Of course, an inhaler only lasts for 10, so some
+actual calculations are needed to do it right.
+  disable auto-recovery?  (uh, it already does that, i think.  In ed_ccAdv)
+  don't bother with buying bandages until we might encounter The Horror or Zerg Rush.
+  handle opening of Hidden City, if we get Such Great Heights unexpectedly when looking for a semi-rare.  (should we still get the semi-rare, in order to have stone wool to finish the quest?  I think so.  It's easy enough to do, anyway.)
+  don't try to open Hidden City if it is already open
+  support clover use for levelling?
+  odd aborts at You the Adventurer
+  aborts from deaths at wisniewski
+  spent a Ka at You the Adventurer
+  spent a Ka at Hidden Apartment Building
+  beaten up by a Zerg Rush  (uh, yeah, that happens.  just make sure the
+script buys some linen bandages, and doesn't abort.)
+  automate screwdriver quest for mys/mus signs
+  (any other needed support for non-muscle signs)
+  use renenutet (and/or cat) in Harem?  (check other uses of lash, too.  probably anywhere we use lash is a good candidate for a renenutet as well)
+  use cat at f'c'le.  oh?  maybe we need Ka, though.  Well, still, I think cat
+would be better.
+  after starting battle with You, aborted with "We can't find the jerk
+adventurer" upon first death.  dunno what was up with that.
+  got "Hit Ed defeat threshold" on second death @ Hippy Camp.
+  double-check that we still work okay with astral mask
+  avoid getting Winklered if we aren't doing nuns.
+  use friar buff @ goatlet
+  avoid extending the Prayer of Seshat +ml buff, when it's time to fight
+ninja.  Let it run out.
+  avoid adventuring twice for a semi-rare, if the first attempt didn't
+auto-stop.  (this can happen if the user manually encounters the warning
+before running the script, or has the bad luck to interrupt the script just
+after it hits the warning.)
+  Are we currently buying Renenutets when budget easily allows it?  Some
+additional tweaks might be nice.
+  fix attempts to equip the same item in all three accessory slots.
+  "Invalid setting 5 for choiceAdventure670"
+  "That area is not available" while trying to get to The mist-shrouded peak!
+(fixed already?)
+  more priority to Even More Elemental Wards. don't buy Armor Plating before
+it.  Fixed, I think.
+  "You are currently in a choice" from pre-adventure for The Horror
+  "You are currently in a fight" at spooky forest.
+  Don't use cat for filthworms, if we have Lash
+  why the 10-turn limit at the hidden park?
+

--- a/etc/Edscension/todo.txt
+++ b/etc/Edscension/todo.txt
@@ -1,47 +1,77 @@
+done:  (of course, see the git repository for a full history; these are just notes)
+- acquire Frat Warrior Fatigues, even if we don't have Wrath of Ra
+- fixes to preparations for The Horror
+
+done?
+- rework of insults & blueprints
+- handle automation of Such Great Heights if semi-rare counter leads us there
+- cast Fist, rather than Storm, when it appears beneficial to do so.
+- use renenutet and/or cat for filthworms, if we don't have Lash.
+- buy spleens & haunches more aggressively, if there is a chance that we might
+  not utilize them otherwise.
+
 
 TODO:
-  horus, shed, sgeea, cure-all, etc.  not sure what things need to be done, exactly....  but we need to avoid unnecessary use of cure-alls.
-  Decision to do nuns might not be quite right.  I count a difference of about
+- use friar buff @ goatlet
+- horus, shed, sgeea, cure-all, etc.  not sure what things need to be done, exactly....  but we need to avoid unnecessary use of cure-alls.
+- support for SMOOCH
+- Decision to do nuns might not be quite right.  I count a difference of about
 25 turns on the battlefield.  Of course, an inhaler only lasts for 10, so some
 actual calculations are needed to do it right.
-  disable auto-recovery?  (uh, it already does that, i think.  In ed_ccAdv)
-  don't bother with buying bandages until we might encounter The Horror or Zerg Rush.
-  handle opening of Hidden City, if we get Such Great Heights unexpectedly when looking for a semi-rare.  (should we still get the semi-rare, in order to have stone wool to finish the quest?  I think so.  It's easy enough to do, anyway.)
-  don't try to open Hidden City if it is already open
-  support clover use for levelling?
-  odd aborts at You the Adventurer
-  aborts from deaths at wisniewski
-  spent a Ka at You the Adventurer
-  spent a Ka at Hidden Apartment Building
-  beaten up by a Zerg Rush  (uh, yeah, that happens.  just make sure the
-script buys some linen bandages, and doesn't abort.)
-  automate screwdriver quest for mys/mus signs
-  (any other needed support for non-muscle signs)
-  use renenutet (and/or cat) in Harem?  (check other uses of lash, too.  probably anywhere we use lash is a good candidate for a renenutet as well)
-  use cat at f'c'le.  oh?  maybe we need Ka, though.  Well, still, I think cat
-would be better.
-  after starting battle with You, aborted with "We can't find the jerk
+- Don't use cat for filthworms, if we have Lash
+- disable auto-recovery?  (uh, it already does that, i think.  In ed_ccAdv)
+- don't bother with buying bandages until we might encounter The Horror or Zerg Rush.
+- handle opening of Hidden City, if we get Such Great Heights unexpectedly when looking for a semi-rare.  (should we still get the semi-rare, in order to have stone wool to finish the quest?  I think so.  It's easy enough to do, anyway.)
+- don't try to open Hidden City if it is already open
+- support clover use for levelling?
+- odd aborts at You the Adventurer
+- after starting battle with You, aborted with "We can't find the jerk
 adventurer" upon first death.  dunno what was up with that.
-  got "Hit Ed defeat threshold" on second death @ Hippy Camp.
-  double-check that we still work okay with astral mask
-  avoid getting Winklered if we aren't doing nuns.
-  use friar buff @ goatlet
-  avoid extending the Prayer of Seshat +ml buff, when it's time to fight
+- aborts from deaths at wisniewski
+- spent a Ka at You the Adventurer
+- spent a Ka at Hidden Apartment Building
+- beaten up by a Zerg Rush  (uh, yeah, that happens.  just make sure the
+script buys some linen bandages, and doesn't abort.  does it still abort?)
+- automate screwdriver quest for mys/mus signs
+- (any other needed support for non-muscle signs)
+- use renenutet (and/or cat) in Harem?  (check other uses of lash, too.
+  probably anywhere we use lash is a good candidate for a renenutet as well.
+  I noticed that Lash was used against a G Imp, but no Renenutet when it failed
+  to elicit a hot wing.)
+- use cat at f'c'le.  oh?  maybe we need Ka, though.  Well, still, I think cat
+would be better.
+- got "Hit Ed defeat threshold" on second death @ Hippy Camp.
+- Why do I sometimes get "Hit Ed defeat threshold" before I need to spend Ka?
+  Where does that come from?  Mafia?  I don't see anything in the scripts....
+- double-check that we still work okay with astral mask
+- avoid getting Winklered if we aren't doing nuns.
+- avoid extending the Prayer of Seshat +ml buff, when it's time to fight
 ninja.  Let it run out.
-  avoid adventuring twice for a semi-rare, if the first attempt didn't
+- avoid adventuring twice for a semi-rare, if the first attempt didn't
 auto-stop.  (this can happen if the user manually encounters the warning
 before running the script, or has the bad luck to interrupt the script just
 after it hits the warning.)
-  Are we currently buying Renenutets when budget easily allows it?  Some
+- Are we currently buying Renenutets when budget easily allows it?  Some
 additional tweaks might be nice.
-  fix attempts to equip the same item in all three accessory slots.
-  "Invalid setting 5 for choiceAdventure670"
-  "That area is not available" while trying to get to The mist-shrouded peak!
+- fix attempts to equip the same item in all three accessory slots.
+- "Invalid setting 5 for choiceAdventure670"
+- "That area is not available" while trying to get to The mist-shrouded peak!
 (fixed already?)
-  more priority to Even More Elemental Wards. don't buy Armor Plating before
+- more priority to Even More Elemental Wards. don't buy Armor Plating before
 it.  Fixed, I think.
-  "You are currently in a choice" from pre-adventure for The Horror
-  "You are currently in a fight" at spooky forest.
-  Don't use cat for filthworms, if we have Lash
-  why the 10-turn limit at the hidden park?
+- "You are currently in a choice" from pre-adventure for The Horror
+- "You are currently in a fight" at spooky forest.
+- why the 10-turn limit at the hidden park?
+- eliminate the "Invalid setting X for choiceAdventureYYY" messages
+- support for eating & drinking.  support for switching the semi-rare
+  consumables collected.
+- improved support for other astral items (bracer works best right now?)
+- other Mr. Store content that chown has?  VIP stuff, CSA
+- if we are looking for the amulet at the airship, use the cat.
+- why was mcd set to 0 for Oil Peak?  Don't I want +ml?
+- I once got "You ran out of restores" after a Zerg Rush.  No abort,
+  just a red message.  But, I hadn't run out.
+- hot plate occasionally interferes with attempts to go shopping (or heal) in
+  the underworld.
+- Improved behavior when low on meat & expensive buffs (Bounty) are available.
 

--- a/etc/Edscension/todo.txt
+++ b/etc/Edscension/todo.txt
@@ -9,6 +9,8 @@ done?
 - use renenutet and/or cat for filthworms, if we don't have Lash.
 - buy spleens & haunches more aggressively, if there is a chance that we might
   not utilize them otherwise.
+- ed_resumeCombat ought to work from the Underworld, or from either of the two
+  choices arriving & departing there.
 
 
 TODO:
@@ -74,4 +76,15 @@ it.  Fixed, I think.
 - hot plate occasionally interferes with attempts to go shopping (or heal) in
   the underworld.
 - Improved behavior when low on meat & expensive buffs (Bounty) are available.
+- what's the deal with the red warning message about "boring binder clip
+  doesn't make anything interesting"?
+- oh, and remove the "testX" messages that appear when the dying/UNDYING status is
+  modified.
+- if I am particularly rich in Ka (say, day 4) I can actually affort to spend
+  more of them on flyering....
+- If Wisniewski is likely to cost Ka, check to see if we have some on hand,
+  and automatically pay the first few.  (I've had to pay 15 total on an
+  unskilled character.)
+
+
 

--- a/scripts/Edscension/ed_ascend.ash
+++ b/scripts/Edscension/ed_ascend.ash
@@ -2831,8 +2831,10 @@ boolean L5_getEncryptionKey()
 		maximize("exp, -ml", 0, 0, false);
 	}
 	print("Looking for the knob.", "blue");
-	ccAdv(1, $location[the outskirts of cobb\'s knob]);
-	cli_execute("refresh inventory");
+	if (0 == item_amount($item[Knob Goblin Encryption Key])) {
+		ccAdv(1, $location[the outskirts of cobb\'s knob]);
+		cli_execute("refresh inventory");
+	}
 
 	if(item_amount($item[Knob Goblin Encryption Key]) == 1)
 	{

--- a/scripts/Edscension/ed_ascend.ash
+++ b/scripts/Edscension/ed_ascend.ash
@@ -3044,7 +3044,7 @@ boolean L9_aBooPeak()
 		return false;
 	}
 	// Allows you to grab the boo-clues you need before finishing off the peak, so you can get the xp from the ghosts you fight, etc.
-	if(get_property("booPeakProgress") > 90)
+	if (to_int(get_property("booPeakProgress")) > 90)
 	{
 		print("A-Boo Peak: " + get_property("booPeakProgress"), "blue");
 		maximize("item drop, 0.5 exp", 0, 0, false);

--- a/scripts/Edscension/ed_ascend.ash
+++ b/scripts/Edscension/ed_ascend.ash
@@ -3058,7 +3058,7 @@ boolean L9_aBooPeak()
 	}
 
 	print("A-Boo Peak: " + get_property("booPeakProgress"), "blue");
-	if(item_amount($item[a-boo clue]) > 0)
+	if(item_amount($item[a-boo clue]) > 0 && to_int("booPeakProgress") > 2)
 	{
 		buffMaintain($effect[Go Get \'Em\, Tiger!], 0, 1, 1);
 		
@@ -3188,7 +3188,7 @@ boolean L9_aBooPeak()
 			use(1, $item[A-Boo clue]);
 			int hpBefore = my_hp();
 			visit_url("adventure.php?snarfblat=296");
-			ccAdv(1, $location[A-Boo Peak]);
+			ed_ccAdv(1, $location[A-Boo Peak], "", true);
 			if (hpBefore - my_hp() < expectedDamage - 5 || expectedDamage + 5 < hpBefore - my_hp()) {
 				print("Calculations predicted " + expectedDamage + " damage, but we took " + (hpBefore - my_hp()) + ".  Need to fix the accuracy!", "red");
 			}

--- a/scripts/Edscension/ed_combat.ash
+++ b/scripts/Edscension/ed_combat.ash
@@ -171,6 +171,7 @@ string ccsJunkyard(int round, string opp, string text)
 	if(!contains_text(edCombatState, "gremlinNeedBanish") && !get_property("ed_gremlinMoly").to_boolean())
 	{
 		set_property("ed_edCombatHandler", "(gremlinNeedBanish)");
+			//TODO:  should that be appended to the state??
 	}
 
 	if(contains_text(text, "It whips out a hammer") || contains_text(text, "He whips out a crescent") || contains_text(text, "It whips out a pair") || contains_text(text, "It whips out a screwdriver"))
@@ -363,9 +364,14 @@ string ed_edCombatHandler(int round, string opp, string text)
 	print("opponent has about " + monster_hp() + " HP.  Ed has " + my_hp() + ".  Fist does " + ed_fistDamage() + ", Storm does (?) " + ed_stormDamage() + ", opponent does " + damagePerRound, "blue");
 	if (get_property("_edDefeats").to_int() != combatStage) print("Note:  _edDefeats is " + get_property("_edDefeats"), "red");
 
-	if((item_amount($item[ka coin]) > 30) && (!have_skill($skill[Healing Scarabs]) || (my_spleen_use() < spleen_limit())) && (get_property("_edDefeats").to_int() == 0) &&
-	(!contains_text(edCombatState, "talismanofrenenutet") || contains_text(edCombatState, "insults") || !contains_text(edCombatState, "curse of fortune")))
-	{
+	if (
+		(item_amount($item[ka coin]) > 30)
+		&& (!have_skill($skill[Healing Scarabs]) || (my_spleen_use() < spleen_limit()))
+		&& (get_property("_edDefeats").to_int() == 0)
+		&& (!contains_text(edCombatState, "talismanofrenenutet") && !contains_text(edCombatState, "curse of fortune") || contains_text(edCombatState, "insults"))
+	) {
+		//TODO:  why?  is this to go shopping?  I think I've handled that elsewhere.
+		//TODO:  fixed (!renenutet)-or-(!fortune) to be !(renenutet-or-fortune)
 		set_property("ed_edStatus", "UNDYING!");
 		print("test5", "red");
 	}

--- a/scripts/Edscension/ed_combat.ash
+++ b/scripts/Edscension/ed_combat.ash
@@ -901,7 +901,7 @@ string ed_edCombatHandler(int round, string opp, string text)
 		//TODO:  dairy goat?
 		if(enemy == $monster[Larval Filthworm] && (item_amount($item[filthworm hatchling scent gland]) == 0))
 		{
-			doRenenutet = (item_amount($item[Talisman of Renenutet]) > 4);
+			doRenenutet = (item_amount($item[Talisman of Renenutet]) > 7);
 		}
 		if(enemy == $monster[Filthworm Drone] && (item_amount($item[filthworm drone scent gland]) == 0))
 		{

--- a/scripts/Edscension/ed_edTheUndying.ash
+++ b/scripts/Edscension/ed_edTheUndying.ash
@@ -1463,8 +1463,8 @@ boolean ed_ccAdv(int num, location loc, string option, boolean skipFirstLife)
 	if(!skipFirstLife)
 	{
 		ed_preAdv(num, loc);
+		ed_use_servant();
 	}
-	ed_use_servant();
 
 	while(num > 0)
 	{

--- a/scripts/Edscension/ed_edTheUndying.ash
+++ b/scripts/Edscension/ed_edTheUndying.ash
@@ -1400,7 +1400,9 @@ boolean ed_handleAdventureServant(location loc)
 		(loc == $location[A Massive Ziggurat] && item_amount($item[stone triangle]) == 0) ||
 		(loc == $location[The Hatching Chamber]) ||
 		(loc == $location[The Feeding Chamber]) ||
-		(loc == $location[The Royal Guard Chamber]))
+		(loc == $location[The Royal Guard Chamber]) ||
+		(loc == $location[Wartime Frat House] && !have_skill($skill[Wrath of Ra]))
+	)
 	{
 		ed_use_servant($servant[Cat]);
 	}

--- a/scripts/Edscension/ed_edTheUndying.ash
+++ b/scripts/Edscension/ed_edTheUndying.ash
@@ -1161,10 +1161,12 @@ ed_ShoppingList ed_buildShoppingList(int kaAdjustment, int adventuresAdjustment)
 		result.skillsToBuy[$skill[Upgraded Spine]] = true;
 		coins -= 20;
 	}
-	/* else if (!have_skill($skill[Upgraded Arms]) && (my_daycount() > 1) && (coins > 20)) {
+	else if (!have_skill($skill[Upgraded Arms]) && (my_daycount() > 1) && (coins > 20)) {
 		result.skillsToBuy[$skill[Upgraded Arms]] = true;
 		coins -= 20;
-	} else if ((!have_skill($skill[Healing Scarabs])) && (my_daycount() > 1) && (coins > 20)) {
+	}
+	/*
+	else if ((!have_skill($skill[Healing Scarabs])) && (my_daycount() > 1) && (coins > 20)) {
 		result.skillsToBuy[$skill[Healing Scarabs]] = true;
 		coins -= 20;
 	} */  // these just seem counterproductive to me.  What are they for?

--- a/scripts/Edscension/ed_edTheUndying.ash
+++ b/scripts/Edscension/ed_edTheUndying.ash
@@ -1496,14 +1496,22 @@ boolean ed_ccAdv(int num, location loc, string option, boolean skipFirstLife)
 		}
 
 		string page = visit_url("main.php");
-		if (contains_text(page, "<b>Combat!</b>")) {
+		matcher m = create_matcher("<input type=hidden name=whichchoice value=([0-9]+)>", page);
+		int whichChoice = m.find() ? m.group(1).to_int() : -1;
+		if (
+			contains_text(page, "<b>Combat!</b>")
+			|| -1 != whichChoice && 1023 != whichChoice && 1024 != whichChoice
+		) {
 			//TODO: are there multi-stage battles where visiting the main map triggers the next one?  Well, I guess Ed works that way, but uh, we don't fight Ed as Ed, do we?  This code assumes that there are no others.
 			adv1(loc, 0, option);
 			page = visit_url("main.php");
 		}
-		if(contains_text(page, "whichchoice value=1023") || contains_text(page, "<b>The Underworld</b>"))
+		if (1023 == whichChoice || 1024 == whichChoice || contains_text(page, "<b>The Underworld</b>"))
 		{
 			print("Ed has UNDYING once!" , "blue");
+			if (1024 == whichChoice) {
+				visit_url("choice.php?pwd=&whichchoice=1024&option=3", true);
+			}
 			if(!ed_shopping())
 			{
 				visit_url("choice.php?pwd=&whichchoice=1023&option=2", true);


### PR DESCRIPTION
A bunch of fairly minor stuff.  Some highlights:

Another fix to stasis logic, to avoid wasting Talismen of Renenutet.  The same fix, I believe, applies to Curse of Fortune.

We now start adventuring at A-Boo before finishing the war, but still defer The Horror until after the war.  (If we manage to get enough clues to finish the peak, then no clovers should be used.)

Re-enabled purchase of Upgraded Arms.  (Low-skilled runs might save a few Ka with the upgrade, and I expect that I will eventually allow The Horror to be encountered before the war is done, in which case the additional HP could be useful.)

If we don't have Wrath of Ra, we now use the cat while getting the frat war outfit.
